### PR TITLE
fix: JSX 닫는 태그 누락 수정

### DIFF
--- a/components/features/MettaTranslator.tsx
+++ b/components/features/MettaTranslator.tsx
@@ -269,6 +269,7 @@ export default function MettaTranslator() {
           </div>
         </div>
       )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
MettaTranslator.tsx에서 누락된 </div> 태그 추가